### PR TITLE
docs(ci): enforce squash merge with conventional commits for automate…

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,0 +1,336 @@
+# Contributing to matlas-cli
+
+Thank you for your interest in contributing to matlas-cli! This guide will help you get started.
+
+## Table of Contents
+
+- [Development Setup](#development-setup)
+- [Pull Request Process](#pull-request-process)
+- [Commit Message Guidelines](#commit-message-guidelines)
+- [Code Style](#code-style)
+- [Testing](#testing)
+- [Feature Development](#feature-development)
+
+## Development Setup
+
+### Prerequisites
+
+- **Go 1.24+** required
+- Git
+- Make (optional, but recommended)
+
+### Getting Started
+
+1. **Fork and clone the repository**:
+   ```bash
+   git clone https://github.com/YOUR_USERNAME/matlas-cli.git
+   cd matlas-cli
+   ```
+
+2. **Install dependencies**:
+   ```bash
+   go mod download
+   ```
+
+3. **Build the project**:
+   ```bash
+   make build
+   # or
+   go build -o bin/matlas ./...
+   ```
+
+4. **Run tests**:
+   ```bash
+   make test
+   ```
+
+## Pull Request Process
+
+### Before Submitting
+
+1. **Create a feature branch** from `main`:
+   ```bash
+   git checkout -b feature/my-feature
+   # or
+   git checkout -b fix/issue-description
+   ```
+
+2. **Make your changes** following our code style and guidelines
+
+3. **Test your changes**:
+   ```bash
+   make test
+   make lint
+   ```
+
+4. **Update documentation** if needed:
+   - Update relevant files in `docs/`
+   - Update `CHANGELOG.md` under `## [Unreleased]` section
+   - Add examples to `examples/` if introducing new features
+   - Create feature tracking file in `features/` using `features/TEMPLATE.md`
+
+### Submitting Your PR
+
+1. **Push your branch**:
+   ```bash
+   git push origin feature/my-feature
+   ```
+
+2. **Open a Pull Request** on GitHub
+
+3. **Fill out the PR template** completely:
+   - Provide clear description
+   - Select the type of change
+   - Specify scope (if applicable)
+   - Provide a **conventional commit message** that will be used for squash merge
+   - Check all applicable items in the checklist
+
+### Merge Process
+
+**This repository uses SQUASH MERGE ONLY**. When your PR is merged:
+
+- All commits will be squashed into a single commit
+- The commit message will be taken from the PR template
+- The commit message MUST follow [Conventional Commits](https://www.conventionalcommits.org/) format
+- This ensures proper versioning and changelog generation via semantic-release
+
+## Commit Message Guidelines
+
+We follow [Conventional Commits](https://www.conventionalcommits.org/) specification for automatic versioning and changelog generation.
+
+### Format
+
+```
+<type>(<optional scope>): <short summary>
+
+<optional body>
+
+<optional footer(s)>
+```
+
+### Types
+
+| Type | Description | Version Impact | In Changelog |
+|------|-------------|----------------|--------------|
+| `feat` | New feature | Minor (0.X.0) | ✅ Features |
+| `fix` | Bug fix | Patch (0.0.X) | ✅ Bug Fixes |
+| `perf` | Performance improvement | Patch (0.0.X) | ✅ Performance |
+| `refactor` | Code refactoring | Patch (0.0.X) | ✅ Refactoring |
+| `docs` | Documentation only | Patch (0.0.X) | ✅ Documentation |
+| `test` | Tests only | None | ❌ Hidden |
+| `build` | Build system or deps | None | ❌ Hidden |
+| `ci` | CI configuration | None | ❌ Hidden |
+| `chore` | Maintenance tasks | None | ❌ Hidden |
+
+### Scopes
+
+Use repository areas for clarity:
+
+- `infra` - Infrastructure/apply workflows
+- `atlas` - Atlas API operations
+- `database` - Database operations
+- `cli` - CLI framework/flags
+- `docs` - Documentation
+- `types` - Type definitions
+- `services` - Service layer
+- etc.
+
+### Examples
+
+**Feature:**
+```
+feat(atlas): add VPC endpoint management commands
+
+Implement create, list, get, and delete operations for Atlas VPC endpoints.
+Supports AWS, Azure, and GCP providers.
+
+Closes: #123
+```
+
+**Bug fix:**
+```
+fix(database): correct pagination when limit is provided
+
+The list operation was ignoring the --limit flag when paginating
+through results. Now properly respects the limit parameter.
+
+Fixes: #456
+```
+
+**Documentation:**
+```
+docs: update installation instructions for Windows
+
+Added PowerShell examples and troubleshooting section.
+```
+
+**Breaking change:**
+```
+feat(infra)!: remove deprecated --legacy flag from apply command
+
+BREAKING CHANGE: The --legacy flag has been removed. Users should
+migrate to the new apply format described in docs/infra.md.
+
+Closes: #789
+```
+
+### Breaking Changes
+
+To mark a breaking change, use one of these methods:
+
+1. **Append `!` after type/scope**:
+   ```
+   feat(api)!: drop support for v1 endpoints
+   ```
+
+2. **Include `BREAKING CHANGE:` footer**:
+   ```
+   feat(infra): update apply pipeline
+   
+   BREAKING CHANGE: removed --legacy flag, use new format instead
+   ```
+
+## Code Style
+
+### Go Code Guidelines
+
+- Follow standard Go conventions and idioms
+- Use `gofmt` for formatting (automatically applied by `make fmt`)
+- Run `make lint` before committing
+- Add comments for exported functions and complex logic
+- Write meaningful variable and function names
+
+### Error Handling
+
+Follow our error handling standards (see `.cursor/rules/error-handling.mdc`):
+
+- Preserve real causes with wrapped errors
+- Support both concise and verbose output modes
+- Use consistent error formatting across commands
+
+### Logging
+
+Follow logging guidelines (see `.cursor/rules/logging.mdc`):
+
+- Use appropriate log levels (Debug, Info, Warn, Error)
+- Automatically mask sensitive data (credentials, connection strings)
+- Provide context in log messages
+
+## Testing
+
+### Running Tests
+
+```bash
+# Run all tests
+make test
+
+# Run specific test package
+go test ./internal/services/atlas/...
+
+# Run with coverage
+go test -cover ./...
+
+# Run with race detector
+go test -race ./...
+```
+
+### Writing Tests
+
+- Write unit tests for new functionality
+- Update existing tests when modifying behavior
+- Use table-driven tests where appropriate
+- Mock external dependencies (Atlas SDK, MongoDB driver)
+- Follow existing test patterns in the codebase
+
+### Live Tests
+
+For integration tests with real Atlas/MongoDB instances:
+
+- Place test scripts in `scripts/`
+- Follow the live tests policy (`.cursor/rules/live-tests.mdc`)
+- Document prerequisites and setup instructions
+
+## Feature Development
+
+When adding new user-facing features, ALWAYS provide:
+
+### 1. CLI Interface
+
+- Add or extend subcommands in the appropriate command group:
+  - `cmd/infra/` - Infrastructure workflows
+  - `cmd/atlas/` - Atlas resource management
+  - `cmd/database/` - Database operations
+  - `cmd/config/` - Configuration management
+
+- Use consistent flag naming and patterns
+- Update command help text and examples
+
+### 2. YAML ApplyDocument Support
+
+If the feature can be expressed declaratively:
+
+- Define or extend types in `internal/types/`
+- Add YAML kind support in `internal/apply/loader.go`
+- Implement validation in `internal/apply/validation.go`
+- Wire execution in `internal/apply/executor.go`
+- Both CLI and YAML must use same `internal/services/*` logic
+
+### 3. Documentation
+
+- Update command documentation in `docs/`
+- Add examples to `examples/`
+- Update `CHANGELOG.md` under `## [Unreleased]`
+- Create feature tracking file in `features/` using template
+
+### 4. Feature Tracking
+
+Create a summary file following `features/TEMPLATE.md`:
+
+```bash
+cp features/TEMPLATE.md features/$(date +%F)-<short-slug>.md
+```
+
+Minimum content:
+- Title: `Feature: <name>`
+- Summary: 2-6 sentences describing the feature
+- Implementation details (CLI, YAML, services, tests, docs)
+
+See `.cursor/rules/feature-format-support.mdc` for complete requirements.
+
+## Documentation Standards
+
+### Writing Documentation
+
+All documentation must:
+
+- Reside under `docs/` directory
+- Use Jekyll frontmatter (layout, title, permalink)
+- Follow GitHub Pages Jekyll setup in `docs/_config.yml`
+- Include code examples with proper syntax highlighting
+- Update navigation in `docs/_config.yml` for new pages
+
+### Preview Documentation Locally
+
+```bash
+cd docs
+bundle install
+bundle exec jekyll serve
+```
+
+Visit `http://localhost:4000/matlas-cli/` to preview.
+
+See `.cursor/rules/documentation-standards.mdc` for complete requirements.
+
+## Getting Help
+
+- **Questions?** Open a [Discussion](https://github.com/teabranch/matlas-cli/discussions)
+- **Bug Reports:** Open an [Issue](https://github.com/teabranch/matlas-cli/issues)
+- **Feature Requests:** Open an [Issue](https://github.com/teabranch/matlas-cli/issues) with the "enhancement" label
+
+## Code of Conduct
+
+Please be respectful and constructive in all interactions. We're building this tool together for the MongoDB community.
+
+---
+
+Thank you for contributing to matlas-cli! 🚀

--- a/.github/SQUASH_MERGE.md
+++ b/.github/SQUASH_MERGE.md
@@ -1,0 +1,216 @@
+# GitHub Squash Merge Configuration
+
+This repository requires **squash merging** for all pull requests to ensure proper semantic versioning and automated releases.
+
+## Repository Settings
+
+Configure the following settings in your GitHub repository:
+
+### 1. Enable Squash Merging Only
+
+Go to: **Settings → General → Pull Requests**
+
+Configure:
+- ✅ **Allow squash merging** - ENABLED
+- ❌ **Allow merge commits** - DISABLED
+- ❌ **Allow rebase merging** - DISABLED
+
+### 2. Configure Squash Merge Commit Message
+
+Under "Allow squash merging", select:
+- **Default commit message**: "Pull request title and description"
+- ✅ **Suggest including pull request description in commit message** - ENABLED
+
+This ensures the PR title and description are used for the squash commit message.
+
+### 3. Enable Branch Protection (Recommended)
+
+Go to: **Settings → Branches → Branch protection rules**
+
+Add rule for `main` branch:
+- ✅ **Require pull request reviews before merging**
+- ✅ **Require status checks to pass before merging**
+  - Select required checks: Release workflow, tests, linting
+- ✅ **Require conversation resolution before merging**
+- ✅ **Do not allow bypassing the above settings**
+
+## Why Squash Merge?
+
+### Benefits
+
+1. **Clean Git History**: Each feature/fix is a single commit on main
+2. **Semantic Versioning**: Commit messages drive automated releases
+3. **Conventional Commits**: PR template enforces proper format
+4. **Easy Rollbacks**: Revert an entire feature with single commit revert
+5. **Better Changelogs**: One commit per feature in release notes
+
+### The Problem with Merge Commits
+
+When using regular merge commits:
+- semantic-release analyzes the **merge commit message**
+- Merge commit format is often: "Merge pull request #123 from branch"
+- This doesn't match Conventional Commits format
+- Result: **No release is triggered** ❌
+
+### Example Comparison
+
+**Before (Merge Commit - BROKEN):**
+```
+Fix/security patches (#13)
+└─ Merge commit message doesn't follow convention
+└─ semantic-release: "The commit should not trigger a release"
+```
+
+**After (Squash Merge - WORKS):**
+```
+fix(security): add secure file operations and credential masking (#13)
+└─ Follows Conventional Commits format
+└─ semantic-release: Triggers patch release 🎉
+```
+
+## How to Configure
+
+### Option 1: Via GitHub Web UI
+
+1. Navigate to your repository settings
+2. Go to **Settings → General**
+3. Scroll to **Pull Requests** section
+4. Configure as described above
+5. Save changes
+
+### Option 2: Via GitHub CLI
+
+```bash
+# Disable merge commits and rebase merging
+gh repo edit owner/repo \
+  --allow-merge-commit=false \
+  --allow-rebase-merge=false \
+  --allow-squash-merge=true
+
+# Enable auto-delete head branches (recommended)
+gh repo edit owner/repo --delete-branch-on-merge=true
+```
+
+### Option 3: Via GitHub API
+
+```bash
+curl -X PATCH \
+  -H "Accept: application/vnd.github.v3+json" \
+  -H "Authorization: token YOUR_TOKEN" \
+  https://api.github.com/repos/owner/repo \
+  -d '{
+    "allow_merge_commit": false,
+    "allow_rebase_merge": false,
+    "allow_squash_merge": true,
+    "delete_branch_on_merge": true
+  }'
+```
+
+## Workflow for Contributors
+
+### 1. Create Feature Branch
+
+```bash
+git checkout -b feature/my-feature
+```
+
+### 2. Make Multiple Commits (Normal Development)
+
+```bash
+git commit -m "wip: start implementing feature"
+git commit -m "add tests"
+git commit -m "fix linting issues"
+git commit -m "address review comments"
+```
+
+These commits can use any format - they'll be squashed!
+
+### 3. Open Pull Request
+
+Use the PR template to provide:
+- Clear description
+- Type of change (feat, fix, docs, etc.)
+- **Conventional commit message** for the squash
+
+### 4. PR Gets Squashed on Merge
+
+All 4 commits become 1 commit with the conventional message:
+
+```
+feat(api): add user authentication endpoints (#123)
+
+Implemented JWT-based authentication with refresh tokens.
+Added middleware for protecting routes.
+Includes comprehensive test coverage.
+
+Closes: #456
+```
+
+## PR Template Enforcement
+
+The PR template guides contributors to:
+
+1. **Select commit type** (feat, fix, docs, etc.)
+2. **Specify scope** (atlas, database, infra, etc.)
+3. **Write conventional commit message** that will be used for squash
+4. **Include breaking change info** if applicable
+
+## Verification
+
+After merging a PR with squash merge:
+
+1. Check the commit on `main` branch
+2. Verify it follows Conventional Commits format
+3. Confirm semantic-release workflow triggers
+4. Verify release is created (if applicable)
+
+## Troubleshooting
+
+### Problem: Release Not Triggered
+
+**Check:**
+- ✅ Squash merge is enabled
+- ✅ PR title/description follows Conventional Commits
+- ✅ Commit type triggers release (feat, fix, perf, refactor, docs)
+- ✅ Not a hidden type (test, build, ci, chore)
+
+**Fix:**
+- Ensure PR template is filled correctly
+- Amend commit message on main if needed:
+  ```bash
+  git commit --amend -m "feat: proper conventional commit message"
+  git push --force-with-lease
+  ```
+
+### Problem: Wrong Commit Message After Merge
+
+**Cause:** PR title/description didn't follow template
+
+**Prevention:**
+- Enable branch protection with required reviews
+- Reviewers should verify commit message format
+- Add GitHub Action to validate PR titles (optional)
+
+### Problem: Multiple Releases Triggered
+
+**Cause:** Multiple PRs merged with different types
+
+**Expected:** Each merged PR can trigger a release if it contains:
+- `feat` → Minor version bump
+- `fix`, `perf`, `refactor`, `docs` → Patch version bump
+
+## Additional Resources
+
+- [Conventional Commits Specification](https://www.conventionalcommits.org/)
+- [semantic-release Documentation](https://semantic-release.gitbook.io/)
+- [GitHub Squash Merge Docs](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/about-pull-request-merges#squash-and-merge-your-commits)
+
+## Summary
+
+✅ **Enable squash merge only**
+✅ **Use PR template for commit messages**
+✅ **Follow Conventional Commits format**
+✅ **Enable branch protection**
+✅ **Review PR commit messages before merging**
+
+This ensures semantic-release can properly analyze commits and trigger releases automatically! 🚀

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,77 @@
+## Description
+
+<!-- Provide a brief description of the changes in this PR -->
+
+## Type of Change
+
+<!-- Select the type of change (this will be used for the commit message) -->
+
+- [ ] `feat`: New feature or enhancement
+- [ ] `fix`: Bug fix
+- [ ] `perf`: Performance improvement
+- [ ] `refactor`: Code refactoring
+- [ ] `docs`: Documentation updates
+- [ ] `test`: Test additions or updates
+- [ ] `build`: Build system or dependency changes
+- [ ] `ci`: CI/CD configuration changes
+- [ ] `chore`: Maintenance tasks
+
+## Scope
+
+<!-- Optional: specify the scope (e.g., atlas, database, infra, cli, docs) -->
+
+**Scope**: 
+
+## Breaking Changes
+
+<!-- If this PR contains breaking changes, check this box and describe them below -->
+
+- [ ] This PR contains breaking changes
+
+**Breaking change description** (if applicable):
+
+## Commit Message
+
+<!-- 
+This will be used as the squash merge commit message.
+Follow Conventional Commits format: <type>(<scope>): <description>
+
+Examples:
+- feat(atlas): add VPC endpoint management commands
+- fix(database): correct pagination in list operation
+- docs: update installation instructions
+- feat(infra)!: remove deprecated --legacy flag
+
+For breaking changes, add ! after type/scope or include BREAKING CHANGE: in footer
+-->
+
+**Suggested commit message**:
+```
+<type>(<scope>): <short description>
+
+<optional body with more details>
+
+<optional footer - e.g., Closes: #123, BREAKING CHANGE: description>
+```
+
+## Checklist
+
+- [ ] Code follows project style guidelines
+- [ ] Self-review completed
+- [ ] Comments added for complex logic
+- [ ] Documentation updated (if needed)
+- [ ] Tests added/updated (if needed)
+- [ ] CHANGELOG.md updated under `## [Unreleased]` section (if user-facing change)
+- [ ] Feature tracking file added to `features/` (if new feature)
+- [ ] Examples added/updated under `examples/` (if new YAML kind or CLI feature)
+
+## Related Issues
+
+<!-- Link related issues using Closes #123, Refs #456, etc. -->
+
+Closes: #
+Refs: #
+
+## Additional Context
+
+<!-- Add any other context, screenshots, or information about the PR here -->

--- a/README.md
+++ b/README.md
@@ -377,6 +377,18 @@ matlas completion powershell > matlas.ps1
 
 ## 🛠️ Development
 
+### Contributing
+
+We welcome contributions! Please see our [Contributing Guide](.github/CONTRIBUTING.md) for:
+- Development setup
+- Pull request process
+- Commit message guidelines (Conventional Commits)
+- Code style standards
+- Testing requirements
+- Feature development workflow
+
+**Important:** This repository uses **squash merge only**. All PRs are squashed into a single commit following [Conventional Commits](https://www.conventionalcommits.org/) format for automated versioning and releases.
+
 ### Commands
 ```bash
 # Run tests

--- a/tracking/documentation.md
+++ b/tracking/documentation.md
@@ -56,3 +56,72 @@ Fixed all broken and incorrect links in the documentation site to resolve Jekyll
 - All changes pushed to `fix/security-patches` branch
 
 ---
+
+## [2025-12-11] GitHub Squash Merge Configuration
+
+**Status**: Completed
+**Developer**: Danny Teller / Assistant
+**Related Issues**: semantic-release not triggering releases due to merge commit format
+
+### Summary
+Configured repository for squash merge only to ensure proper semantic versioning and automated releases. Created comprehensive documentation for contributors on conventional commits and squash merge workflow.
+
+### Tasks
+- [x] Create PR template with conventional commit format guidance
+- [x] Create CONTRIBUTING.md with full development guidelines
+- [x] Create SQUASH_MERGE.md with GitHub configuration instructions
+- [x] Update README.md with contributing section
+- [x] Add tracking entry for documentation changes
+
+### Files Modified
+- `.github/pull_request_template.md` - NEW: PR template enforcing conventional commits
+- `.github/CONTRIBUTING.md` - NEW: Comprehensive contributing guide with squash merge policy
+- `.github/SQUASH_MERGE.md` - NEW: GitHub repository configuration guide
+- `README.md` - Added contributing section linking to new documentation
+- `tracking/documentation.md` - Added this tracking entry
+
+### Notes
+
+**Problem Identified:**
+- Merge commit message "Fix/security patches (#13)" didn't follow Conventional Commits format
+- semantic-release couldn't parse commit type, didn't trigger release
+- Individual commits in PR were correct, but merge commit format was wrong
+
+**Solution Implemented:**
+1. **PR Template**: Guides contributors to provide conventional commit message for squash
+2. **Contributing Guide**: Complete documentation on:
+   - Conventional Commits specification
+   - Commit types and their version impacts
+   - Scope guidelines
+   - Breaking change syntax
+   - Feature development workflow
+   - Testing requirements
+   
+3. **Squash Merge Guide**: Instructions for repository maintainers to:
+   - Configure GitHub settings (disable merge commits and rebase)
+   - Enable squash merge only
+   - Configure branch protection rules
+   - Use PR title/description for commit message
+
+**Benefits:**
+- Clean git history (one commit per feature/fix)
+- Automatic semantic versioning from commit messages
+- Proper changelog generation
+- Easy rollbacks (single commit per feature)
+- Consistent commit format enforcement
+
+**Next Steps:**
+- Configure GitHub repository settings via web UI or CLI
+- Test with a sample PR to verify semantic-release triggers properly
+- Consider adding GitHub Action to validate PR titles (optional enhancement)
+
+**Configuration Required (Manual):**
+```bash
+gh repo edit teabranch/matlas-cli \
+  --allow-merge-commit=false \
+  --allow-rebase-merge=false \
+  --allow-squash-merge=true \
+  --delete-branch-on-merge=true
+```
+
+---


### PR DESCRIPTION
…d releases

Add comprehensive documentation and templates to enforce squash merge workflow and conventional commits, fixing semantic-release integration.

Changes:
- Add .github/pull_request_template.md: Guide contributors to provide conventional commit message in PR description for squash merge
- Add .github/CONTRIBUTING.md: Complete contributing guide covering development setup, PR process, conventional commits, code style, testing, and feature development workflow
- Add .github/SQUASH_MERGE.md: Repository configuration instructions for maintainers to enable squash merge only via GitHub settings or CLI
- Update README.md: Add contributing section linking to new documentation and emphasizing squash merge requirement
- Update tracking/documentation.md: Document this configuration work

Problem Solved:
Previous PR #13 merge commit "Fix/security patches (#13)" didn't follow conventional commit format, causing semantic-release to skip release. Squash merge ensures single commit per PR with proper format.

Benefits:
- Clean git history (one commit per feature/fix)
- Automatic semantic versioning from commit messages
- Proper changelog generation via semantic-release
- Easy rollbacks with single commit per feature
- Consistent commit format enforcement

Configuration Required:
Repository maintainer must configure GitHub settings to disable merge commits and rebase merging, enable squash merge only. Instructions provided in .github/SQUASH_MERGE.md.

Refs: #13